### PR TITLE
fix(focus-key): action should reflection updated options

### DIFF
--- a/demo/FocusKeyActionUpdates.svelte
+++ b/demo/FocusKeyActionUpdates.svelte
@@ -15,7 +15,7 @@
 <div>
   <button
     on:click={() => {
-      key = Array.isArray(key) ? "k" : ["/"];
+      key = key === "/" ? "k" : "/";
       selectText = !selectText;
     }}
   >

--- a/demo/FocusKeyActionUpdates.svelte
+++ b/demo/FocusKeyActionUpdates.svelte
@@ -1,0 +1,24 @@
+<script>
+  import { focusKey } from "svelte-focus-key";
+
+  let selectText = false;
+  let key = "k";
+  let value = "text";
+</script>
+
+<input
+  use:focusKey={{ key, selectText }}
+  placeholder={'Press "k" to focus'}
+  bind:value
+/>
+
+<div>
+  <button
+    on:click={() => {
+      key = Array.isArray(key) ? "k" : ["/"];
+      selectText = !selectText;
+    }}
+  >
+    Toggle options
+  </button>
+</div>

--- a/src/focus-key.ts
+++ b/src/focus-key.ts
@@ -14,7 +14,6 @@ export function focusKey(
   const keydown = (e: KeyboardEvent) => {
     if (
       keys.some((key) => key === e.key) &&
-      element != null &&
       document.activeElement?.tagName === "BODY" &&
       document.activeElement !== element
     ) {

--- a/src/focus-key.ts
+++ b/src/focus-key.ts
@@ -7,9 +7,10 @@ export function focusKey(
   element: HTMLInputElement | HTMLTextAreaElement,
   options: FocusKeyOptions = {}
 ) {
-  const key = options.key || "/";
-  const keys = Array.isArray(key) ? key : [key];
-  const selectText = options.selectText === true;
+  let key = options.key || "/";
+  let keys = Array.isArray(key) ? key : [key];
+  let selectText = options.selectText === true;
+
   const keydown = (e: KeyboardEvent) => {
     if (
       keys.some((key) => key === e.key) &&
@@ -26,6 +27,12 @@ export function focusKey(
   document.body.addEventListener("keydown", keydown);
 
   return {
+    update(options: FocusKeyOptions = {}) {
+      key = options.key || "/";
+      keys = Array.isArray(key) ? key : [key];
+      selectText = options.selectText === true;
+      element.selectionStart = element.selectionEnd;
+    },
     destroy() {
       document.body.removeEventListener("keydown", keydown);
     },

--- a/tests/focus-key.test.ts
+++ b/tests/focus-key.test.ts
@@ -1,4 +1,3 @@
-import { tick } from "svelte";
 import { test, expect, describe, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { focusKey } from "../src";
@@ -49,7 +48,7 @@ describe("focus-key", () => {
     expect(document.activeElement).not.toEqual(input);
   });
 
-  test("Multiple focus keys", async () => {
+  test("Multiple focus keys", () => {
     document.body.innerHTML = `
       <input />
     `;


### PR DESCRIPTION
```svelte
<script>
  import { focusKey } from "svelte-focus-key";

  let selectText = false;
  let key = "k";
  let value = "text";
</script>

<input
  use:focusKey={{ key, selectText }}
  placeholder={'Press "k" to focus'}
  bind:value
/>

<div>
  <button
    on:click={() => {
      key = key === "/" ? "k" : "/";
      selectText = !selectText;
    }}
  >
    Toggle options
  </button>
</div>

```