### PR TITLE
feat: support combination of keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ The `key` prop can also accept an array of keys.
 
 <!-- example-end -->
 
+### Combination of keys
+
+A combination of keys should be separated by a `+`.
+
+<!-- example-start demo/ComboKeys.svelte -->
+
+```svelte
+<script>
+  import FocusKey from "svelte-focus-key";
+
+  let element;
+</script>
+
+<input bind:this={element} placeholder={'Press "⌘+k" to focus'} />
+
+<FocusKey {element} key="Meta+k" />
+```
+
+<!-- example-end -->
+
 ### Select text on focus
 
 Set `selectText` to `true` to select the text in the element when focusing.
@@ -116,7 +136,7 @@ This utility also provides a [Svelte action](https://svelte.dev/docs#use_action)
   import { focusKey } from "svelte-focus-key";
 </script>
 
-<input use:focusKey={{ key: "k" }} placeholder={'Press "k" to focus'} />
+<input use:focusKey={{ key: "q" }} placeholder={'Press "q" to focus'} />
 ```
 
 <!-- example-end -->

--- a/demo/ComboKeys.svelte
+++ b/demo/ComboKeys.svelte
@@ -1,0 +1,9 @@
+<script>
+  import FocusKey from "svelte-focus-key";
+
+  let element;
+</script>
+
+<input bind:this={element} placeholder={'Press "⌘+k" to focus'} />
+
+<FocusKey {element} key="Meta+k" />

--- a/demo/FocusKeyAction.svelte
+++ b/demo/FocusKeyAction.svelte
@@ -2,4 +2,4 @@
   import { focusKey } from "svelte-focus-key";
 </script>
 
-<input use:focusKey={{ key: "k" }} placeholder={'Press "k" to focus'} />
+<input use:focusKey={{ key: "q" }} placeholder={'Press "q" to focus'} />

--- a/src/FocusKey.svelte
+++ b/src/FocusKey.svelte
@@ -15,13 +15,20 @@
   export let selectText = false;
 
   $: keys = Array.isArray(key) ? key : [key];
+
+  let pressedKeys: string[] = [];
 </script>
 
 <svelte:body
   on:keydown={(e) => {
+    pressedKeys = [...pressedKeys, e.key];
+  }}
+  on:keyup={(e) => {
+    const currentKey = pressedKeys.join("+");
+
     if (
-      keys.some((key) => key === e.key) &&
-      element != null &&
+      keys.some((key) => key === currentKey) &&
+      element !== null &&
       document.activeElement?.tagName === "BODY" &&
       document.activeElement !== element
     ) {
@@ -29,4 +36,7 @@
       element.focus();
       if (selectText) element.select();
     }
-  }} />
+
+    pressedKeys = [];
+  }}
+/>

--- a/src/focus-key.ts
+++ b/src/focus-key.ts
@@ -21,10 +21,18 @@ const setOptions = (options: FocusKeyOptions = {}) => {
 
 export const focusKey: FocusKeyAction = (element, options) => {
   let { keys, selectText } = setOptions(options);
+  let pressedKeys: string[] = [];
 
   const keydown = (e: KeyboardEvent) => {
+    pressedKeys = [...pressedKeys, e.key];
+  };
+
+  const keyup = (e: KeyboardEvent) => {
+    const currentKey = pressedKeys.join("+");
+
     if (
-      keys.some((key) => key === e.key) &&
+      keys.some((key) => key === currentKey) &&
+      element !== null &&
       document.activeElement?.tagName === "BODY" &&
       document.activeElement !== element
     ) {
@@ -32,9 +40,12 @@ export const focusKey: FocusKeyAction = (element, options) => {
       element.focus();
       if (selectText) element.select();
     }
+
+    pressedKeys = [];
   };
 
   document.body.addEventListener("keydown", keydown);
+  document.body.addEventListener("keyup", keyup);
 
   return {
     update(options) {
@@ -43,6 +54,7 @@ export const focusKey: FocusKeyAction = (element, options) => {
     },
     destroy() {
       document.body.removeEventListener("keydown", keydown);
+      document.body.removeEventListener("keyup", keyup);
     },
   };
 };

--- a/tests/FocusKey.test.ts
+++ b/tests/FocusKey.test.ts
@@ -1,10 +1,10 @@
-import { test, expect, describe, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { tick } from "svelte";
-import { default as FocusKey } from "../src";
+import { default as FocusKey } from "svelte-focus-key";
+import { afterEach, describe, expect, test } from "vitest";
 
 describe("FocusKey", () => {
-  let instance: FocusKey = null;
+  let instance: null | FocusKey = null;
 
   afterEach(() => {
     instance?.$destroy();
@@ -19,7 +19,7 @@ describe("FocusKey", () => {
       </div>
     `;
 
-    const target = document.getElementById("target");
+    const target = document.getElementById("target")!;
     const input = document.querySelector("input")!;
 
     instance = new FocusKey({
@@ -47,7 +47,7 @@ describe("FocusKey", () => {
       </div>
     `;
 
-    const target = document.getElementById("target");
+    const target = document.getElementById("target")!;
     const input = document.querySelector("input")!;
 
     instance = new FocusKey({
@@ -73,7 +73,7 @@ describe("FocusKey", () => {
       </div>
     `;
 
-    const target = document.getElementById("target");
+    const target = document.getElementById("target")!;
     const input = document.querySelector("input")!;
 
     instance = new FocusKey({
@@ -113,5 +113,27 @@ describe("FocusKey", () => {
     await userEvent.keyboard("y");
     expect(input.selectionStart).toEqual(0);
     expect(input.selectionEnd).toEqual(1);
+  });
+
+  test("Combo keys", async () => {
+    document.body.innerHTML = `
+      <div id="target">
+        <input />
+      </div>
+    `;
+
+    const target = document.getElementById("target")!;
+    const input = document.querySelector("input")!;
+
+    instance = new FocusKey({
+      target,
+      props: {
+        element: input,
+        key: ["Meta+k"],
+      },
+    });
+
+    await userEvent.keyboard("{meta>}{k}");
+    expect(document.activeElement).toEqual(input);
   });
 });

--- a/tests/focus-key.test.ts
+++ b/tests/focus-key.test.ts
@@ -1,5 +1,5 @@
-import { test, expect, describe, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, test } from "vitest";
 import { focusKey } from "../src";
 
 describe("focus-key", () => {
@@ -29,9 +29,7 @@ describe("focus-key", () => {
   });
 
   test("Custom focus key 's'", async () => {
-    document.body.innerHTML = `
-      <input />
-    `;
+    document.body.innerHTML = "<input />";
 
     const input = document.querySelector("input")!;
 
@@ -67,6 +65,24 @@ describe("focus-key", () => {
     input.blur();
 
     await userEvent.keyboard("/");
+    expect(input.selectionStart).toEqual(0);
+    expect(input.selectionEnd).toEqual(4);
+  });
+
+  test("Combo keys", async () => {
+    document.body.innerHTML = "<input />";
+
+    const input = document.querySelector("input")!;
+
+    instance = focusKey(input, { key: ["Meta+k"], selectText: true });
+
+    await userEvent.keyboard("{meta>}{k}");
+    expect(document.activeElement).toEqual(input);
+
+    await userEvent.keyboard("text");
+    input.blur();
+
+    await userEvent.keyboard("{meta>}{k}");
     expect(input.selectionStart).toEqual(0);
     expect(input.selectionEnd).toEqual(4);
   });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "vitest";
+import { expect, test } from "vitest";
+import * as pkg from "../package.json";
 import * as API from "../src";
-import pkg from "../package.json";
 
 test("Library has 0 dependencies", () => {
   // @ts-expect-error

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
+    "resolveJsonModule": true,
     "strict": true,
     "paths": {
       "$lib": ["src"],


### PR DESCRIPTION
Closes #8

PR to support a combination of keys (delimited by a "+"), e.g., `⌘+k`.